### PR TITLE
Add variable to install plugins at deployment

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then
+  OLDIFS=$IFS
+  IFS=','
+  for plugin in ${GF_INSTALL_PLUGINS}; do
+    grafana-cli --pluginsDir /usr/share/grafana/data/plugins plugins install ${plugin}
+  done
+  IFS=$OLDIFS
+fi
 source /etc/sysconfig/grafana-server
 cd /usr/share/grafana
 /usr/sbin/grafana-server \


### PR DESCRIPTION
GF_INSTALL_PLUGINS variable added to run.sh

docker run \
  -d \
  -p 3000:3000 \
  --name=grafana \
  -e "GF_INSTALL_PLUGINS=grafana-clock-panel,grafana-simple-json-datasource" \
  grafana/grafana

Inspired by https://github.com/grafana/grafana-docker