### PR TITLE
Fixed a syntax issue in the run script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,5 +5,5 @@ cd /usr/share/grafana
 --config=${CONF_FILE} \
 --pidfile=${PID_FILE} \
 cfg:default.paths.logs=${LOG_DIR} \
-cfg:default.paths.data=${DATA_DIR} \ 
+cfg:default.paths.data=${DATA_DIR} \
 cfg:default.paths.plugins=${PLUGINS_DIR}


### PR DESCRIPTION
This additional space at the end of the line will cause the space to get escaped not the newline.

Which will trigger the last line to be executed instead of appended, resulting in:

```
INFO[01-13|11:11:07] Plugin dir created                       logger=plugins dir=data/plugins
INFO[01-13|11:11:07] Server Listening                         logger=server address=0.0.0.0:3000 protocol=http subUrl=
^CINFO[01-13|11:12:05] Received signal [interrupt]. shutting down 
./run.sh: line 9: cfg:default.paths.plugins=/var/lib/grafana/plugins: No such file or directory
``` 

And also not adding the option to the command line of the original command.